### PR TITLE
Fix bug with model-defaults and collection-model rules

### DIFF
--- a/lib/rules/collection-model.js
+++ b/lib/rules/collection-model.js
@@ -13,7 +13,6 @@ var helper = require("../../backbone-helper.js");
 module.exports = function(context) {
 
     var backboneCollection = [];
-    var foundModel = false;
 
     //--------------------------------------------------------------------------
     // Public
@@ -21,23 +20,23 @@ module.exports = function(context) {
 
     return {
         "CallExpression": function(node) {
-            backboneCollection.push(backboneCollection[backboneCollection.length - 1] || helper.isBackboneCollection(node));
-            if (backboneCollection[backboneCollection.length - 1]) {
-                foundModel = false;
+            if (helper.isBackboneCollection(node)) {
+                backboneCollection.push({ node: node, found: false });
             }
         },
         "CallExpression:exit": function(node) {
-            if (helper.isBackboneCollection(node)) {
-                if (!foundModel) {
+            var lastCollection = backboneCollection[backboneCollection.length - 1];
+            if (backboneCollection.length > 0 && lastCollection.node === node) {
+                if (!lastCollection.found) {
                     context.report(node, "All collections should have model declared");
                 }
                 backboneCollection.pop();
             }
         },
         "Identifier": function(node) {
-            if (backboneCollection[backboneCollection.length - 1] && node.name === "model") {
+            if (backboneCollection.length > 0 && node.name === "model") {
                 if (helper.checkIfPropertyInBackboneCollection(node)) {
-                    foundModel = true;
+                    backboneCollection[backboneCollection.length - 1].found = true;
                 }
             }
         }

--- a/lib/rules/model-defaults.js
+++ b/lib/rules/model-defaults.js
@@ -13,7 +13,6 @@ var helper = require("../../backbone-helper.js");
 module.exports = function(context) {
 
     var backboneModel = [];
-    var foundDefaults = false;
 
     //--------------------------------------------------------------------------
     // Public
@@ -21,23 +20,23 @@ module.exports = function(context) {
 
     return {
         "CallExpression": function(node) {
-            backboneModel.push(backboneModel[backboneModel.length - 1] || helper.isBackboneModel(node));
-            if (backboneModel[backboneModel.length - 1]) {
-                foundDefaults = false;
+            if (helper.isBackboneModel(node)) {
+                backboneModel.push({ node: node, found: false });
             }
         },
         "CallExpression:exit": function(node) {
-            if (helper.isBackboneModel(node)) {
-                if (!foundDefaults) {
+            var lastModel = backboneModel[backboneModel.length - 1];
+            if (backboneModel.length > 0 && lastModel.node === node) {
+                if (!lastModel.found) {
                     context.report(node, "All models should have defaults declared");
                 }
                 backboneModel.pop();
             }
         },
         "Identifier": function(node) {
-            if (backboneModel[backboneModel.length - 1] && node.name === "defaults") {
+            if (backboneModel.length > 0 && node.name === "defaults") {
                 if (helper.checkIfPropertyInBackboneModel(node)) {
-                    foundDefaults = true;
+                    backboneModel[backboneModel.length - 1].found = true;
                 }
             }
         }

--- a/tests/lib/rules/model-defaults.js
+++ b/tests/lib/rules/model-defaults.js
@@ -25,7 +25,8 @@ eslintTester.addRuleTest("lib/rules/model-defaults", {
         "Backbone.Model.extend({ constructor: function() { Backbone.Model.apply(this, arguments); }, defaults: {} });",
         "Backbone.Model.extend({ initialize: function() { var a = Backbone.Model.extend({ defaults: {} });}, defaults: {} });",
         "Backbone.Models.extend();",
-        "var a=6 * 7;"
+        "var a=6 * 7;",
+        "Backbone.Model.extend({ defaults: {}, initialize: function() { alert(); } });"
     ],
 
     invalid: [


### PR DESCRIPTION
Previously any CallExpression inside Backbone.Model or Collection would make `model-defaults` and `collection-model` rules fail. This should fix it.
