### PR TITLE
Adding options to events-on-top (fixes #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Enable all of the rules that you would like to use
         "backbone/defaults-on-top": 1,
         "backbone/model-defaults": 1,
         "backbone/no-constructor": 1,
-        "backbone/no-native-jquery": 1
+        "backbone/no-native-jquery": 1,
+        ...
     }
 }
 ```

--- a/docs/rules/events-on-top.md
+++ b/docs/rules/events-on-top.md
@@ -30,6 +30,19 @@ Backbone.View.extend({
 
 ```
 
+## Options
+
+This rule accepts an array op strings that would be excluded from the check. For example, if you use `tagName` or `className` properties in your Views and would like them to be declared before `events`, you can enable this rule with the following options:
+
+```json
+
+"rules" : {
+    "backbone/events-on-top": [1, ['tagName', 'className']],
+    ...
+}
+
+```
+
 ## Further Reading
 
 [BackboneJS Documentation](http://backbonejs.org/#View)

--- a/lib/rules/events-on-top.js
+++ b/lib/rules/events-on-top.js
@@ -22,8 +22,22 @@ module.exports = function(context) {
         "Identifier": function(node) {
             if (node.name === "events") {
                 var parent = node.parent, grandparent = parent.parent;
-                if (helper.checkIfPropertyInBackboneView(node, settings.backbone) && grandparent.type === "ObjectExpression" &&  grandparent.properties[0] !== parent) {
-                    context.report(node, "events should be declared at the top of the view.");
+                if (helper.checkIfPropertyInBackboneView(node, settings.backbone) && grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent) {
+                    if (context.options && context.options.length > 0) {
+                        //we have exceptions passed into the rule, verify that any property that goes before events is in the options list
+                        for (var i = 0, l = grandparent.properties.length; i < l; i++) {
+                            if (grandparent.properties[i] === parent) {
+                                break;
+                            }
+                            if ((grandparent.properties[i].key.type === "Identifier" && context.options[0].indexOf(grandparent.properties[i].key.name) === -1) ||
+                                (grandparent.properties[i].key.type === "Literal" && context.options[0].indexOf(grandparent.properties[i].key.value) === -1)) {
+                                context.report(node, "events should be declared at the top of the view.");
+                                break;
+                            }
+                        }
+                    } else {
+                        context.report(node, "events should be declared at the top of the view.");
+                    }
                 }
             }
         }

--- a/tests/lib/rules/events-on-top.js
+++ b/tests/lib/rules/events-on-top.js
@@ -22,12 +22,22 @@ eslintTester.addRuleTest("lib/rules/events-on-top", {
         "Backbone.View.extend({ events: {}, initialize: function() {} });",
         "Backbone.View.extend({ });",
         "Backbone.View.extend({ initialize: function() {} });",
-        "Backbone.View.extend({ initialize: function() { var events = {}; } });"
+        "Backbone.View.extend({ initialize: function() { var events = {}; } });",
+        { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {} });", args: [1, ["tagName", "className"]] }
     ],
 
     invalid: [
         {
             code: "Backbone.View.extend({ initialize: function() {}, events: {} });", errors: 1
+        },
+        {
+            code: "Backbone.View.extend({ initialize: function() {}, tagName: 'div', 'className': 'test', events: {} });", args: [1, ["tagName", "className"]], errors: 1
+        },
+        {
+            code: "Backbone.View.extend({ tagName: 'div', initialize: function() {}, 'className': 'test', events: {} });", args: [1, ["tagName", "className"]], errors: 1
+        },
+        {
+            code: "Backbone.View.extend({ render: function() {}, initialize: function() {}, 'className': 'test', events: {} });", args: [1, ["tagName", "className"]], errors: 1
         }
     ]
 });


### PR DESCRIPTION
Options should be added in the following format

```
[1, ["tagName", "className", "initialize"]]
```
