### PR TITLE
Update no-native-jquery with options (fixes #33)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage/
 build/
 npm-debug.log
 .DS_Store
+.idea/

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Defaults are currently set to the following:
     "no-constructor": 1,
     "no-el-assign": 2,
     "no-model-attributes": 2,
-    "no-native-jquery": 0,
+    "no-native-jquery": [1, "selector"],
     "no-silent": 1,
     "no-view-collection-models": 2,
     "no-view-model-attributes": 2,

--- a/docs/rules/no-native-jquery.md
+++ b/docs/rules/no-native-jquery.md
@@ -28,6 +28,13 @@ Backbone.View.extend({
 
 ```
 
+## Options
+
+This rule supports two modes `all` or `selector`. `all` is the default mode, when on, it will check for any uses of jQuery
+in the view. `selector` will only warn about jQuery selectors that are using literals, as in, if you are passing a string
+into jQuery's `$` function, it will warn you, but if you are passing an object, it will skip over it. `selector` mode is
+useful if you are working with event handlers and need to wrap event's target into jQuery object.
+
 ## When Not To Use It
 
 When writing a small application sometimes it's easier to operate on external elements, instead of creating a new view.

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
         "no-constructor": 1,
         "no-el-assign": 2,
         "no-model-attributes": 2,
-        "no-native-jquery": 0,
+        "no-native-jquery": [1, "selector"],
         "no-silent": 1,
         "no-view-collection-models": 2,
         "no-view-model-attributes": 2,

--- a/lib/rules/no-native-jquery.js
+++ b/lib/rules/no-native-jquery.js
@@ -33,6 +33,16 @@ module.exports = function(context) {
                 var ancestors = context.getAncestors(node), parent = ancestors.pop();
 
                 if (parent.type === "CallExpression") {
+                    if (context.options && context.options.length > 0) {
+                        if (context.options[0] === "selector" && parent.arguments && parent.arguments.length > 0) {
+                            if (parent.arguments[0].type === "Literal") {
+                                context.report(node, "Use this.$ instead of $ in views");
+                                return;
+                            } else {
+                                return;
+                            }
+                        }
+                    }
                     context.report(node, "Use this.$ instead of $ in views");
                 }
             }

--- a/tests/lib/rules/no-native-jquery.js
+++ b/tests/lib/rules/no-native-jquery.js
@@ -24,7 +24,8 @@ eslintTester.addRuleTest("lib/rules/no-native-jquery", {
         "Backbone.View.extend({ test: function() { return $.isArray(a); } });",
         "Backbone.Model.extend({ initialize: function() { var a = $('.item').offset(); } });",
         "var a = 6 * 7;",
-        "var a = $('.item').offset();"
+        "var a = $('.item').offset();",
+        { code: "Backbone.View.extend({ render: function(element) { $(element).show(); } });", args: [1, "selector"] }
     ],
 
     invalid: [
@@ -38,6 +39,14 @@ eslintTester.addRuleTest("lib/rules/no-native-jquery", {
         },
         {
             code: "Backbone.View.extend({ initialize: function() { Backbone.View.apply(this, arguments); var a = $('.item').offset(); } });",
+            errors: [ { message: "Use this.$ instead of $ in views" } ]
+        },
+        {
+            code: "Backbone.View.extend({ render: function(element) { $(element).show(); } });", args: [1, "all"],
+            errors: [ { message: "Use this.$ instead of $ in views" } ]
+        },
+        {
+            code: "Backbone.View.extend({ render: function() { $('.item').show(); } });", args: [1, "selector"],
             errors: [ { message: "Use this.$ instead of $ in views" } ]
         }
     ]


### PR DESCRIPTION
Adding two options for `no-native-jquery`, `all` and `selector`. Changing default configuration to include `no-native-jquery` by default as a warning with `selector` option.