### PR TITLE
Fix exponentially growing settings arrays. (fixes #29)

### DIFF
--- a/lib/backbone-helper.js
+++ b/lib/backbone-helper.js
@@ -23,14 +23,16 @@ function parseSettings(settings) {
     });
 }
 
-function normalizeSettings(settings) {
+function normalizeSettings(originalSettings) {
     "use strict";
-    settings = settings || {};
-    settings.Collection = settings.Collection ? settings.Collection.concat("Backbone.Collection") : ["Backbone.Collection"];
+    originalSettings = originalSettings || {};
+    
+    var settings = {};
+    settings.Collection = originalSettings.Collection ? originalSettings.Collection.concat("Backbone.Collection") : ["Backbone.Collection"];
     settings.Collection = parseSettings(settings.Collection);
-    settings.Model = settings.Model ? settings.Model.concat("Backbone.Model") : ["Backbone.Model"];
+    settings.Model = originalSettings.Model ? originalSettings.Model.concat("Backbone.Model") : ["Backbone.Model"];
     settings.Model = parseSettings(settings.Model);
-    settings.View = settings.View ? settings.View.concat("Backbone.View") : ["Backbone.View"];
+    settings.View = originalSettings.View ? originalSettings.View.concat("Backbone.View") : ["Backbone.View"];
     settings.View = parseSettings(settings.View);
     return settings;
 }


### PR DESCRIPTION
normalizeSettings is invoked every time isBackboneView/Model/Collection is invoked (for every rule in the plugin, for every node).
This causes exponential growth in the arrays of the settings object, which slows down the linear searches performed in isBackboneBase.  A simple fix is to create a new Object every time normalizeSettings is invoked.

If the settings do not change over the lifetime of the process, then the normalized settings can be cached for further performance benefit.  The same can be done for the prefixes array created in isBackboneBase.  The unit tests do change the settings, so some checking needs to be implemented to detect cache hits/misses, or the unit tests need to be modified.

@rsk7 @gshenar helped me profile, analyze, and fix this issue.