### PR TITLE
New: no-view-qualified-jquery rule (fixes #48)

### DIFF
--- a/docs/rules/no-view-qualified-jquery.md
+++ b/docs/rules/no-view-qualified-jquery.md
@@ -1,0 +1,87 @@
+# Prevent usage of global $ to reach view elements (no-view-qualified-jquery)
+
+When operating on Backbone views outside of other Backbone contexts, it is easy to forget that views provide their own functions for accessing elements. These functions should be favored because the jQuery selector scope is limited to the view's root element automatically.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+/* eslint backbone/no-view-qualified-jquery: 2 */
+
+$('.some-selector', view.el);
+
+$('.some-selector', view.$el);
+
+$('.some-selector', $(view.el));
+
+$('.some-selector', $(view.$el));
+
+jQuery('.some-selector', view.el);
+
+jQuery('.some-selector', view.$el);
+
+jQuery('.some-selector', jQuery(view.el));
+
+jQuery('.some-selector', jQuery(view.$el));
+
+$('.some-selector', myView.el);
+
+$('.some-selector', myView.$el);
+
+$('.some-selector', $(myView.el));
+
+$('.some-selector', $(myView.$el));
+
+```
+
+With the `identifiers` option configured to a different value, the following patterns are considered warnings:
+
+```js
+/* eslint backbone/no-view-qualified-jquery: [2, { identifiers: ["myJQuery"] }] */
+
+myJQuery('.some-selector', myView.el);
+
+myJQuery('.some-selector', myView.$el);
+
+myJQuery('.some-selector', myJQuery(myView.el));
+
+myJQuery('.some-selector', myJQuery(myView.$el));
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+/* eslint backbone/no-view-qualified-jquery: 2 */
+
+$('.some-selector');
+
+jQuery('.some-selector');
+
+view.$('.some-selector');
+
+view.$el.find('.some-selector');
+
+```
+
+With the `identifiers` option configured to a different value, the following pattern is not considered a warning:
+
+```js
+/* eslint backbone/no-view-qualified-jquery: [2, { identifiers: ["myJQuery"] }] */
+
+$('.some-selector', view.el);
+
+```
+
+## Options
+
+This rule supports a single options object. The options object can have one option: `identifiers`. This represents what global identifiers represent the jQuery library and is set to `["$", "jQuery"]` by default. However, if you use `jQuery.noConflict()` or AMD to set jQuery to use a different global, you can specify that in the options object. Note that you must provide an array of identifiers.
+
+## When Not To Use It
+
+If this rule results in too many false positives, it can be safely disabled.
+
+## Further Reading
+
+[BackboneJS Documentation](http://backbonejs.org/#View-dollar)

--- a/lib/rules/no-view-qualified-jquery.js
+++ b/lib/rules/no-view-qualified-jquery.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Prevent usage of native jQuery scoped to view elements
+ * @author Kevin Partington
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var DEFAULT_JQUERY_ALIASES = ["jQuery", "$"],
+    VIEW_ELEMENT_MEMBERS = ["el", "$el"],
+    ERROR_TEMPLATE = "Use {{identifier}}.$ or {{identifier}}.$el.find instead of view-scoped native jQuery";
+
+module.exports = function(context) {
+    var options,
+        sourceCode = context.getSourceCode();
+        
+    options = context.options[0] || {
+        identifiers: DEFAULT_JQUERY_ALIASES
+    };
+
+    function isNativeJQuery(node) {
+        return node.type === "Identifier" &&
+            options.identifiers.indexOf(node.name) !== -1;
+    }
+
+    function isPotentialViewElement(node) {
+        return node.type === "MemberExpression" &&
+            node.property &&
+            node.property.type === "Identifier" &&
+            VIEW_ELEMENT_MEMBERS.indexOf(node.property.name) !== -1;
+    }
+
+    function isJQueryWrappedPotentialViewElement(node) {
+        return node.type === "CallExpression" &&
+            node.arguments.length &&
+            isNativeJQuery(node.callee) &&
+            isPotentialViewElement(node.arguments[0]);
+    }
+
+    function isArgumentViewQualifier(node) {
+        return isPotentialViewElement(node) ||
+            isJQueryWrappedPotentialViewElement(node);
+    }
+
+    function getViewIdentifier(node) {
+        if (isPotentialViewElement(node)) {
+            return sourceCode.getText(node.object);
+        }
+
+        return sourceCode.getText(node.arguments[0].object);
+    }
+
+    function checkForViewQualifiedJQuery(node) {
+        // View qualified jQuery is defined in terms of second argument to
+        // jQuery call. Argument may be in the form of view.el, view.$el, or
+        // $(view.el) or $(view.$el).
+
+        /* istanbul ignore else: correctly does nothing */
+        if (isArgumentViewQualifier(node.arguments[1])) {
+            context.report(node, ERROR_TEMPLATE, {
+                identifier: getViewIdentifier(node.arguments[1])
+            });
+        }
+    }
+
+    return {
+        "CallExpression": function(node) {
+            /* istanbul ignore else: correctly does nothing */
+            if (isNativeJQuery(node.callee) && node.arguments.length > 1) {
+                checkForViewQualifiedJQuery(node);
+            }
+        }
+    };
+};
+
+module.exports.schema = [
+    {
+        type: "object",
+        properties: {
+            identifiers: {
+                type: "array"
+            }
+        },
+        additionalProperties: false
+    }
+];

--- a/tests/lib/rules/no-view-qualified-jquery.js
+++ b/tests/lib/rules/no-view-qualified-jquery.js
@@ -1,0 +1,117 @@
+/**
+ * @fileoverview Prevent usage of native jQuery scoped to view elements
+ * @author Kevin Partington
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var RuleTester = require("eslint").RuleTester;
+var rule = require("../../../lib/rules/no-view-qualified-jquery");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ERROR_TEMPLATE = "Use {{placeholder}}.$ or {{placeholder}}.$el.find instead of view-scoped native jQuery";
+
+function createErrorMessage(identifier) {
+    return ERROR_TEMPLATE.replace(/\{\{placeholder\}\}/g, identifier);
+}
+
+var eslintTester = new RuleTester();
+eslintTester.run("no-view-qualified-jquery", rule, {
+    valid: [
+        // Simple cases
+        "$('.some-selector');",
+        "jQuery('.some-selector');",
+        "view.$('.some-selector');",
+        "view.$el.find('.some-selector');",
+
+        // Rule should not warn if jQuery identifier is configured differently
+        {
+            code: "$('.some-selector', view.el);",
+            options: [{ identifiers: ["myJQuery"] }]
+        }
+    ],
+
+    invalid: [
+        // Simple cases
+        {
+            code: "$('.some-selector', view.el);",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "$('.some-selector', view.$el);",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "$('.some-selector', $(view.el));",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "$('.some-selector', $(view.$el));",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+
+        // Using jQuery identifier
+        {
+            code: "jQuery('.some-selector', view.el);",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "jQuery('.some-selector', view.$el);",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "jQuery('.some-selector', jQuery(view.el));",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "jQuery('.some-selector', jQuery(view.$el));",
+            errors: [{ message: createErrorMessage("view") }]
+        },
+
+        // Using different view identifier
+        {
+            code: "$('.some-selector', myView.el);",
+            errors: [{ message: createErrorMessage("myView") }]
+        },
+        {
+            code: "$('.some-selector', myView.$el);",
+            errors: [{ message: createErrorMessage("myView") }]
+        },
+        {
+            code: "$('.some-selector', $(myView.el));",
+            errors: [{ message: createErrorMessage("myView") }]
+        },
+        {
+            code: "$('.some-selector', $(myView.$el));",
+            errors: [{ message: createErrorMessage("myView") }]
+        },
+
+        // Using different jQuery identifier
+        {
+            code: "myJQuery('.some-selector', view.el);",
+            options: [{ identifiers: ["myJQuery"] }],
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "myJQuery('.some-selector', view.$el);",
+            options: [{ identifiers: ["myJQuery"] }],
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "myJQuery('.some-selector', myJQuery(view.el));",
+            options: [{ identifiers: ["myJQuery"] }],
+            errors: [{ message: createErrorMessage("view") }]
+        },
+        {
+            code: "myJQuery('.some-selector', myJQuery(view.$el));",
+            options: [{ identifiers: ["myJQuery"] }],
+            errors: [{ message: createErrorMessage("view") }]
+        }
+    ]
+});


### PR DESCRIPTION
As discussed, this uses the heuristic of a `.el` or `.$el` property access to infer that a native `$` call might be scoped to a view element.

Fixes #48.