### PR TITLE
Support event map syntax in the event-scope rule

### DIFF
--- a/docs/rules/event-scope.md
+++ b/docs/rules/event-scope.md
@@ -1,6 +1,6 @@
 # Verify that scope is passed into event handlers (event-scope)
 
-When binding event handlers for Backbone events such as `add`, `remove`, etc. it's a good idea to pass third parameter that will switch context. While sometimes it's not necessary, in most cases it will make your code more consistent and easier to understand. This rule applies to `on` and `once` operators.
+When binding event handlers for Backbone events such as `add`, `remove`, etc. it's a good idea to pass a parameter that will switch context. While sometimes it's not necessary, in most cases it will make your code more consistent and easier to understand. This rule applies to `on` and `once` operators.
 
 ## Rule Details
 
@@ -10,10 +10,15 @@ The following patterns are considered warnings:
 
 Backbone.Model.extend({
     initialize: function() {
-        this.on('change', this.modelChanged); 
+        this.on('change', this.modelChanged);
     }
 });
 
+Backbone.Model.extend({
+    initialize: function() {
+        this.on({'change': this.modelChanged});
+    }
+});
 ```
 
 The following patterns are not warnings:
@@ -26,6 +31,11 @@ Backbone.Model.extend({
     }
 });
 
+Backbone.Model.extend({
+    initialize: function() {
+        this.on({'change': this.modelChanged}, this);
+    }
+});
 ```
 
 ## When Not To Use It

--- a/lib/rules/event-scope.js
+++ b/lib/rules/event-scope.js
@@ -38,7 +38,9 @@ module.exports = function(context) {
                 while (parent.type !== "CallExpression" && !parent.arguments) {
                     parent = ancestors.pop();
                 }
-                if (parent.arguments.length < 3) {
+                if (parent.arguments.length === 1 && parent.arguments[0].type === 'ObjectExpression') {
+                    context.report(node, "Pass scope as second argument.");
+                } else if (parent.arguments.length < 3 && (parent.arguments[0] || {}).type !== 'ObjectExpression') {
                     context.report(node, "Pass scope as third argument.");
                 }
             }

--- a/tests/lib/rules/event-scope.js
+++ b/tests/lib/rules/event-scope.js
@@ -24,7 +24,8 @@ eslintTester.run("event-scope", rule, {
         "Backbone.View.extend({ initialize: function() { this.model.on('change', this.test, this); } });",
         "Backbone.View.extend({ initialize: function() { this.$el.on('click', this.test); } });",
         "Backbone.View.extend({ initialize: function() { $('test').on('click', this.test); } });",
-        "Backbone.View.extend({ initialize: function() { this.$('.something').on('change', this.update); } });"
+        "Backbone.View.extend({ initialize: function() { this.$('.something').on('change', this.update); } });",
+        "Backbone.View.extend({ initialize: function() { this.on({'click': this.test, 'destroy': this.update}, this); } });"
     ],
 
     invalid: [
@@ -34,6 +35,14 @@ eslintTester.run("event-scope", rule, {
         },
         {
             code: "Backbone.Model.extend({ initialize: function() { this.model.once('change', this.modelChanged); } })",
+            errors: [ { message: "Pass scope as third argument." } ]
+        },
+        {
+            code: "Backbone.View.extend({ initialize: function() { this.model.on({'change': this.modelChanged}); } });",
+            errors: [ { message: "Pass scope as second argument." } ]
+        },
+        {
+            code: "Backbone.Model.extend({ initialize: function() { this.model.on(); } });",
             errors: [ { message: "Pass scope as third argument." } ]
         }
     ]


### PR DESCRIPTION
Backbone supports event binding using a map syntax.  This change provides support for that syntax.  The result of this rule should be identical when the first argument is not an object literal.  For simplicity, I didn't consider ambiguous cases such as when the first argument is an identifier, which satisfies my current need.  I can make the rule more sophisticated if desired.