### PR TITLE
Do not warn of native jQuery usage on DOM creation mode

### DIFF
--- a/lib/rules/no-native-jquery.js
+++ b/lib/rules/no-native-jquery.js
@@ -36,8 +36,12 @@ module.exports = function(context) {
                     if (context.options && context.options.length > 0) {
                         if (context.options[0] === "selector" && parent.arguments && parent.arguments.length > 0) {
                             if (parent.arguments[0].type === "Literal") {
-                                context.report(node, "Use this.$ instead of $ in views");
-                                return;
+                                if (parent.arguments[0].value.match(/^<.*>$/)) {
+                                    return;
+                                } else {
+                                    context.report(node, "Use this.$ instead of $ in views");
+                                    return;
+                                }
                             } else {
                                 return;
                             }

--- a/lib/rules/no-native-jquery.js
+++ b/lib/rules/no-native-jquery.js
@@ -36,7 +36,7 @@ module.exports = function(context) {
                     if (context.options && context.options.length > 0) {
                         if (context.options[0] === "selector" && parent.arguments && parent.arguments.length > 0) {
                             if (parent.arguments[0].type === "Literal") {
-                                if (parent.arguments[0].value.match(/^<.*>$/)) {
+                                if (parent.arguments[0].value.match(/^<.*>$/) || (parent.arguments.length === 2 && parent.arguments[1].type !== 'Literal')) {
                                     return;
                                 } else {
                                     context.report(node, "Use this.$ instead of $ in views");

--- a/tests/lib/rules/no-native-jquery.js
+++ b/tests/lib/rules/no-native-jquery.js
@@ -26,7 +26,8 @@ eslintTester.run("no-native-jquery", rule, {
         "var a = 6 * 7;",
         "var a = $('.item').offset();",
         { code: "Backbone.View.extend({ render: function(element) { $(element).show(); } });", options: ["selector"] },
-        { code: "Backbone.View.extend({ render: function() { var a = $('<div></div>'); } });", options: ["selector"] }
+        { code: "Backbone.View.extend({ render: function() { var a = $('<div></div>'); } });", options: ["selector"] },
+        { code: "Backbone.View.extend({ render: function() { var a = $('<div><span></span></div>'), b = $('span', a); } });", options: ["selector"] }
     ],
 
     invalid: [

--- a/tests/lib/rules/no-native-jquery.js
+++ b/tests/lib/rules/no-native-jquery.js
@@ -25,7 +25,8 @@ eslintTester.run("no-native-jquery", rule, {
         "Backbone.Model.extend({ initialize: function() { var a = $('.item').offset(); } });",
         "var a = 6 * 7;",
         "var a = $('.item').offset();",
-        { code: "Backbone.View.extend({ render: function(element) { $(element).show(); } });", options: ["selector"] }
+        { code: "Backbone.View.extend({ render: function(element) { $(element).show(); } });", options: ["selector"] },
+        { code: "Backbone.View.extend({ render: function() { var a = $('<div></div>'); } });", options: ["selector"] }
     ],
 
     invalid: [


### PR DESCRIPTION
Checks if jQuery argument matches "<...>", and thus is not a selector, i.e. permits `$('<div>Hello</div>').appendTo(..)`
(Propably) Fixes #46 , even though not sure because of poorly formatted issue...