### PR TITLE
Update peer dependency to handle eslint >= 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-backbone",
-  "version": "2.0.0",
+  "version": "2.0.2",
   "description": "Eslint rules for Backbone.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "eslint": "^2.0.0"
   },
   "peerDependencies": {
-    "eslint": "^2.0.0"
+    "eslint": ">=2.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
eslint 3.0 was recently released, but eslint ^2.0.0 is listed as a peer dependency in `package.json`. This might cause a warning on a dev machine and a failure in a CI environment. This PR updates the peer dependency to also accept 3.0.0 and greater.

Also, bump package version number to 2.0.2.