### PR TITLE
Add rule for enforcing alphabetic sorting of keys in a views event hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Defaults are currently set to the following:
 
 ## Configuration
 
-In version 2.0.0 removed support for default configurations for plugins and replaced it with ability for plugins to bundle configs. This plugin include `recommended` 
+In version 2.0.0 removed support for default configurations for plugins and replaced it with ability for plugins to bundle configs. This plugin include `recommended`
 configuration that you can extend from to enable recommended setup of the rules (see "Default configuration" for the list of enabled rules).
 
 To enable bundled config modify your .eslintrc file to include the following line:
@@ -129,6 +129,7 @@ If you are using custom models/view/collection bases you also have to specify ea
 * [defaults-on-top](docs/rules/defaults-on-top.md)
 * [event-scope](docs/rules/event-scope.md)
 * [events-on-top](docs/rules/events-on-top.md)
+* [events-sort](docs/rules/events-sort.md)
 * [initialize-on-top](docs/rules/initialize-on-top.md)
 * [model-defaults](docs/rules/model-defaults.md)
 * [no-changed-set](/docs/rules/no-changed-set.md)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Defaults are currently set to the following:
 
 ## Configuration
 
-In version 2.0.0 removed support for default configurations for plugins and replaced it with ability for plugins to bundle configs. This plugin include `recommended`
+In version 2.0.0 removed support for default configurations for plugins and replaced it with ability for plugins to bundle configs. This plugin include `recommended` 
 configuration that you can extend from to enable recommended setup of the rules (see "Default configuration" for the list of enabled rules).
 
 To enable bundled config modify your .eslintrc file to include the following line:

--- a/docs/rules/events-sort.md
+++ b/docs/rules/events-sort.md
@@ -1,0 +1,42 @@
+# Event names in event hash should be sorted alphabetically (events-sort)
+
+If events are declared on the view, their keys should be sorted alphabetically to improve predictability of the code.
+
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+Backbone.View.extend({
+    events: {
+        'submit': 'handleSubmit',
+        'click': 'handleClick'
+    }
+    ...
+});
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+Backbone.View.extend({
+    events: {
+        'blur': 'handleBlur',
+        'click': 'handleClick',
+        'submit': 'handleSubmit'
+    }
+    ...
+});
+
+```
+
+## When Not To Use It
+
+When you do not use `events` extensively or your views usually only handle a small number of events.
+
+## Further Reading
+
+[BackboneJS Documentation](http://backbonejs.org/#View)

--- a/lib/rules/events-sort.js
+++ b/lib/rules/events-sort.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Event names in event hash should be sorted alphabetically
+ * @author Frederik Ring
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var helper = require("../backbone-helper.js");
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "Event names in event hash should be sorted alphabetically",
+            category: "Stylistic",
+            recommended: false
+        },
+        schema: [
+            {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "uniqueItems": true
+                },
+                "additionalProperties": false
+            }
+        ]
+    },
+    create: function(context) {
+
+        var settings = context.settings || /* istanbul ignore next */ {};
+
+        //--------------------------------------------------------------------------
+        // Public
+        //--------------------------------------------------------------------------
+
+        return {
+            "Identifier": function(node) {
+                if (node.name === "events") {
+                    if (helper.checkIfPropertyInBackboneView(node, settings.backbone)) {
+                        var keys = node.parent.value.properties.map(function(prop) {
+                            return prop.key.value || prop.key.name;
+                        });
+                        var sortedKeys = keys.slice().sort();
+                        for (var i = 0; i < keys.length; i++) {
+                            if (keys[i] !== sortedKeys[i]){
+                                context.report(node, "event names in event hash should be sorted alphabetically.");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/events-sort.js
+++ b/tests/lib/rules/events-sort.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Event names in event hash should be sorted alphabetically
+ * @author Frederik Ring
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var RuleTester = require("eslint").RuleTester;
+var rule = require("../../../lib/rules/events-sort");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new RuleTester();
+eslintTester.run("events-sort", rule, {
+
+    valid: [
+        "Backbone.View.extend({ events: {}, initialize: function() {} });",
+        "Backbone.View.extend({ events: {'click': 'handleClick', 'submit': 'handleSubmit'}, initialize: function() {} });",
+        "Backbone.View.extend({ events: { click: 'handleClick', 'submit': 'handleSubmit'}, initialize: function() {} });",
+        "Backbone.View.extend({ });",
+        "Backbone.View.extend({ initialize: function() {} });",
+        "Backbone.View.extend({ initialize: function() { var events = {'foo': '2', 'bar': 3}; } });",
+        "Backbone.View.extend({ events: {'blur': 'handleBlur', 'click': 'handleClick', 'submit': 'handleSubmit'} });",
+        "Backbone.View.extend({ events: {'blur .a': 'handleBlur', 'blur .b': 'handleBlur', 'blur .c': 'handleBlur'} });"
+    ],
+
+    invalid: [
+        {
+            code: "Backbone.View.extend({ events: {'submit': 'handleSubmit', 'click': 'handleClick'} });",
+            errors: [ { message: "event names in event hash should be sorted alphabetically." } ]
+        },
+        {
+            code: "Backbone.View.extend({ events: {'blur': 'handleBlur', 'submit': 'handleSubmit', 'click': 'handleClick'} });",
+            errors: [ { message: "event names in event hash should be sorted alphabetically." } ]
+        },
+        {
+            code:         "Backbone.View.extend({ events: {'blur .a': 'handleBlur', 'blur .z': 'handleBlur', 'blur .c': 'handleBlur'} });",
+            errors: [ { message: "event names in event hash should be sorted alphabetically." } ]
+        },
+        {
+            code: "Backbone.View.extend({ events: {submit: 'handleSubmit', 'click': 'handleClick'} });",
+            errors: [ { message: "event names in event hash should be sorted alphabetically." } ]
+        }
+    ]
+});


### PR DESCRIPTION
This adds a rule that enforces the keys of a view's event hash to be sorted alphabetically (which I like to do).

This is my first time ever creating an eslint rule so I might have missed major aspects of doing this. Feel free to point them out.