### PR TITLE
Fix render-return to work with custom base class

### DIFF
--- a/lib/rules/render-return.js
+++ b/lib/rules/render-return.js
@@ -22,6 +22,7 @@ module.exports = {
     },
     create: function(context) {
 
+        var settings = context.settings || /* istanbul ignore next */ {};
         var inBackboneRender = null;
         var returnFound = false;
 
@@ -32,7 +33,7 @@ module.exports = {
         return {
             "FunctionExpression": function(node) {
                 if (node.parent.type === "Property" && node.parent.key.type === "Identifier" && node.parent.key.name === "render") {
-                    if (helper.checkIfPropertyInBackboneView(node.parent.key)) {
+                    if (helper.checkIfPropertyInBackboneView(node.parent.key, settings.backbone)) {
                         inBackboneRender = node;
                         returnFound = false;
                     }

--- a/tests/lib/rules/render-return.js
+++ b/tests/lib/rules/render-return.js
@@ -38,6 +38,11 @@ eslintTester.run("render-return", rule, {
         {
             code: "Backbone.View.extend({ render: function() { return; } });",
             errors: [ { message: "render method should always return 'this'" } ]
+        },
+        {
+            code: "Test.extend({ render: function() { return; } });",
+            settings: { backbone: { View: ["Test"] }},
+            errors: [ { message: "render method should always return 'this'" } ]
         }
     ]
 });


### PR DESCRIPTION
The `render-return` rule was not calling some of it's helper functions with the settings object, so rule failures with custom base classes were not being detected.

This fixes the issue and adds an associated test (which fails before the fix and succeeds afterwards).