### PR TITLE
Fix crash when applying "on-top" rules to ES6 modules

### DIFF
--- a/lib/rules/defaults-on-top.js
+++ b/lib/rules/defaults-on-top.js
@@ -40,7 +40,7 @@ module.exports = {
             "Identifier": function(node) {
                 if (node.name === "defaults") {
                     var parent = node.parent, grandparent = parent.parent;
-                    if (helper.checkIfPropertyInBackboneModel(node, settings.backbone) && grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent) {
+                    if (grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent && helper.checkIfPropertyInBackboneModel(node, settings.backbone)) {
                         if (context.options && context.options.length > 0) {
                             //we have exceptions passed into the rule, verify that any property that goes before events is in the options list
                             for (var i = 0, l = grandparent.properties.length; i < l; i++) {

--- a/lib/rules/events-on-top.js
+++ b/lib/rules/events-on-top.js
@@ -40,7 +40,7 @@ module.exports = {
             "Identifier": function(node) {
                 if (node.name === "events") {
                     var parent = node.parent, grandparent = parent.parent;
-                    if (helper.checkIfPropertyInBackboneView(node, settings.backbone) && grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent) {
+                    if (grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent && helper.checkIfPropertyInBackboneView(node, settings.backbone)) {
                         if (context.options && context.options.length > 0) {
                             //we have exceptions passed into the rule, verify that any property that goes before events is in the options list
                             for (var i = 0, l = grandparent.properties.length; i < l; i++) {

--- a/lib/rules/initialize-on-top.js
+++ b/lib/rules/initialize-on-top.js
@@ -49,7 +49,7 @@ module.exports = {
             "Identifier": function(node) {
                 if (node.name === "initialize") {
                     var parent = node.parent, grandparent = parent.parent;
-                    if (helper.checkIfPropertyInBackbone(node, settings.backbone) && grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent) {
+                    if (grandparent.type === "ObjectExpression" && grandparent.properties[0] !== parent && helper.checkIfPropertyInBackbone(node, settings.backbone)) {
                         if (context.options && context.options.length > 0) {
                             var backboneTypeOptions = [];
                             var backboneType = "";

--- a/tests/lib/rules/defaults-on-top.js
+++ b/tests/lib/rules/defaults-on-top.js
@@ -15,7 +15,12 @@ var rule = require("../../../lib/rules/defaults-on-top");
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+var eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
 eslintTester.run("defaults-on-top", rule, {
 
     valid: [
@@ -25,7 +30,8 @@ eslintTester.run("defaults-on-top", rule, {
         "Backbone.Model.extend({ initialize: function() { var defaults = {}; } });",
         { code: "Backbone.Model.extend({ id: 'someId', defaults: {} });", options: [["id"]] },
         { code: "Backbone.Model.extend({ 'idAttribute': '_id', defaults: {} });", options: [["idAttribute"]] },
-        "var defaults;"
+        "var defaults;",
+        "export default defaults;"
     ],
 
     invalid: [
@@ -44,17 +50,4 @@ eslintTester.run("defaults-on-top", rule, {
             errors: [ { message: "defaults should be declared at the top of the model." } ]
         }
     ]
-});
-
-eslintTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 8,
-        sourceType: "module"
-    }
-});
-eslintTester.run("events-on-top", rule, {
-    valid: [
-        "export default defaults;"
-    ],
-    invalid: []
 });

--- a/tests/lib/rules/defaults-on-top.js
+++ b/tests/lib/rules/defaults-on-top.js
@@ -24,7 +24,8 @@ eslintTester.run("defaults-on-top", rule, {
         "Backbone.Model.extend({ initialize: function() {} });",
         "Backbone.Model.extend({ initialize: function() { var defaults = {}; } });",
         { code: "Backbone.Model.extend({ id: 'someId', defaults: {} });", options: [["id"]] },
-        { code: "Backbone.Model.extend({ 'idAttribute': '_id', defaults: {} });", options: [["idAttribute"]] }
+        { code: "Backbone.Model.extend({ 'idAttribute': '_id', defaults: {} });", options: [["idAttribute"]] },
+        "var defaults;"
     ],
 
     invalid: [
@@ -43,4 +44,17 @@ eslintTester.run("defaults-on-top", rule, {
             errors: [ { message: "defaults should be declared at the top of the model." } ]
         }
     ]
+});
+
+eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
+eslintTester.run("events-on-top", rule, {
+    valid: [
+        "export default defaults;"
+    ],
+    invalid: []
 });

--- a/tests/lib/rules/events-on-top.js
+++ b/tests/lib/rules/events-on-top.js
@@ -23,7 +23,8 @@ eslintTester.run("events-on-top", rule, {
         "Backbone.View.extend({ });",
         "Backbone.View.extend({ initialize: function() {} });",
         "Backbone.View.extend({ initialize: function() { var events = {}; } });",
-        { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {} });", options: [["tagName", "className"]] }
+        { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {} });", options: [["tagName", "className"]] },
+        "var events;"
     ],
 
     invalid: [
@@ -44,4 +45,17 @@ eslintTester.run("events-on-top", rule, {
             errors: [ { message: "events should be declared at the top of the view." } ]
         }
     ]
+});
+
+eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
+eslintTester.run("events-on-top", rule, {
+    valid: [
+        "export default events;"
+    ],
+    invalid: []
 });

--- a/tests/lib/rules/events-on-top.js
+++ b/tests/lib/rules/events-on-top.js
@@ -15,7 +15,12 @@ var rule = require("../../../lib/rules/events-on-top");
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+var eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
 eslintTester.run("events-on-top", rule, {
 
     valid: [
@@ -24,7 +29,8 @@ eslintTester.run("events-on-top", rule, {
         "Backbone.View.extend({ initialize: function() {} });",
         "Backbone.View.extend({ initialize: function() { var events = {}; } });",
         { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {} });", options: [["tagName", "className"]] },
-        "var events;"
+        "var events;",
+        "export default events;"
     ],
 
     invalid: [
@@ -45,17 +51,4 @@ eslintTester.run("events-on-top", rule, {
             errors: [ { message: "events should be declared at the top of the view." } ]
         }
     ]
-});
-
-eslintTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 8,
-        sourceType: "module"
-    }
-});
-eslintTester.run("events-on-top", rule, {
-    valid: [
-        "export default events;"
-    ],
-    invalid: []
 });

--- a/tests/lib/rules/initialize-on-top.js
+++ b/tests/lib/rules/initialize-on-top.js
@@ -28,7 +28,8 @@ eslintTester.run("initialize-on-top", rule, {
         "Backbone.View.extend({ render: function() {} });",
         { code: "Backbone.Model.extend({ defaults: {}, initialize: function() {} });", options: [{ Model: ["defaults"] }] },
         { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {}, initialize: function() {} });", options: [{ View: ["tagName", "className", "events"] }] },
-        { code: "Backbone.Collection.extend({ model: {}, initialize: function() {} });", options: [{ Collection: ["model"] }] }
+        { code: "Backbone.Collection.extend({ model: {}, initialize: function() {} });", options: [{ Collection: ["model"] }] },
+        "var initialize;"
     ],
 
     invalid: [
@@ -61,4 +62,17 @@ eslintTester.run("initialize-on-top", rule, {
             errors: [ { message: "Initialize should be declared at the top of the collection." } ]
         }
     ]
+});
+
+eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
+eslintTester.run("events-on-top", rule, {
+    valid: [
+        "export default initialize;"
+    ],
+    invalid: []
 });

--- a/tests/lib/rules/initialize-on-top.js
+++ b/tests/lib/rules/initialize-on-top.js
@@ -15,7 +15,12 @@ var rule = require("../../../lib/rules/initialize-on-top");
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new RuleTester();
+var eslintTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 8,
+        sourceType: "module"
+    }
+});
 eslintTester.run("initialize-on-top", rule, {
 
     valid: [
@@ -29,7 +34,8 @@ eslintTester.run("initialize-on-top", rule, {
         { code: "Backbone.Model.extend({ defaults: {}, initialize: function() {} });", options: [{ Model: ["defaults"] }] },
         { code: "Backbone.View.extend({ tagName: 'div', 'className': 'test', events: {}, initialize: function() {} });", options: [{ View: ["tagName", "className", "events"] }] },
         { code: "Backbone.Collection.extend({ model: {}, initialize: function() {} });", options: [{ Collection: ["model"] }] },
-        "var initialize;"
+        "var initialize;",
+        "export default initialize;"
     ],
 
     invalid: [
@@ -62,17 +68,4 @@ eslintTester.run("initialize-on-top", rule, {
             errors: [ { message: "Initialize should be declared at the top of the collection." } ]
         }
     ]
-});
-
-eslintTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 8,
-        sourceType: "module"
-    }
-});
-eslintTester.run("events-on-top", rule, {
-    valid: [
-        "export default initialize;"
-    ],
-    invalid: []
 });


### PR DESCRIPTION
* Add tests for applying `on-top` rules to ES6 modules
* Fix crash when applying `on-top` rules to ES6 modules
  * The greatgrandparent of an ES6 module "export" statement is null. Avoid further inspection of these nodes in "checkIfPropertyInBackboneModel" by first checking whether they are part of an "ObjectExpression" at all.

Fixes #66 