### PR TITLE
Run CI tests on the latest LTS Node.js release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "lts/*"
 sudo: false
 notifications:
    email: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ eslint-plugin-backbone
 
 [Backbone](http://backbonejs.org) specific linting rules for [ESLint](http://www.eslint.org)
 
-#How to use
+# How to use
 
 ## Install [ESLint](https://www.github.com/eslint/eslint) either locally or globally
 
@@ -123,7 +123,7 @@ If you are using custom models/view/collection bases you also have to specify ea
 }
 ```
 
-#List of supported rules
+# List of supported rules
 
 * [collection-model](docs/rules/collection-model.md)
 * [defaults-on-top](docs/rules/defaults-on-top.md)


### PR DESCRIPTION
This will run tests with support for ES8 syntax.

Also, fix formatting errors in README.