### PR TITLE
Docs: Simplify no-view-qualified-jquery examples

### DIFF
--- a/docs/rules/no-view-qualified-jquery.md
+++ b/docs/rules/no-view-qualified-jquery.md
@@ -50,21 +50,6 @@ myJQuery('.some-selector', myJQuery(myView.$el));
 
 ```
 
-The following patterns are not considered warnings:
-
-```js
-/* eslint backbone/no-view-qualified-jquery: 2 */
-
-$('.some-selector');
-
-jQuery('.some-selector');
-
-view.$('.some-selector');
-
-view.$el.find('.some-selector');
-
-```
-
 With the `identifiers` option configured to a different value, the following pattern is not considered a warning:
 
 ```js


### PR DESCRIPTION
Simplifying the presentation of examples by removing a mostly extraneous set of examples.