### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/collection-model.js
+++ b/lib/rules/collection-model.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Require all collections to declare model",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/collection-model.md"
         },
         schema: []
     },

--- a/lib/rules/defaults-on-top.js
+++ b/lib/rules/defaults-on-top.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Require defaults to be on top of the model",
             category: "Stylistic",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/defaults-on-top.md"
         },
         schema: [
             {

--- a/lib/rules/event-scope.js
+++ b/lib/rules/event-scope.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Verify that scope is passed into event handlers",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/event-scope.md"
         },
         schema: []
     },

--- a/lib/rules/events-on-top.js
+++ b/lib/rules/events-on-top.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Events should be the first thing registered in the View",
             category: "Stylistic",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/events-on-top.md"
         },
         schema: [
             {

--- a/lib/rules/events-sort.js
+++ b/lib/rules/events-sort.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Event names in event hash should be sorted alphabetically",
             category: "Stylistic",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/events-sort.md"
         },
         schema: [
             {

--- a/lib/rules/initialize-on-top.js
+++ b/lib/rules/initialize-on-top.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Requires initialize to be the first property of Backbone Views/Models/Collections",
             category: "Stylistic",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/initialize-on-top.md"
         },
         schema: [
             {

--- a/lib/rules/model-defaults.js
+++ b/lib/rules/model-defaults.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Require all models to have defaults section",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/model-defaults.md"
         },
         schema: []
     },

--- a/lib/rules/no-changed-set.js
+++ b/lib/rules/no-changed-set.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent setting changed attribute of the model in views",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-changed-set.md"
         },
         schema: []
     },

--- a/lib/rules/no-collection-models.js
+++ b/lib/rules/no-collection-models.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent access to models property of collections",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-collection-models.md"
         },
         schema: []
     },

--- a/lib/rules/no-constructor.js
+++ b/lib/rules/no-constructor.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent overloading of constructor",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-constructor.md"
         },
         schema: []
     },

--- a/lib/rules/no-el-assign.js
+++ b/lib/rules/no-el-assign.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent assigning el or $el inside views",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-el-assign.md"
         },
         schema: []
     },

--- a/lib/rules/no-model-attributes.js
+++ b/lib/rules/no-model-attributes.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent access to attributes collection inside models",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-model-attributes.md"
         },
         schema: []
     },

--- a/lib/rules/no-native-jquery.js
+++ b/lib/rules/no-native-jquery.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent usage of $ in the views",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-native-jquery.md"
         },
         schema: [
             {

--- a/lib/rules/no-silent.js
+++ b/lib/rules/no-silent.js
@@ -16,7 +16,8 @@ module.exports = {
         docs: {
             description: "Prevent using silent option in functions that cause events",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-silent.md"
         },
         schema: []
     },

--- a/lib/rules/no-view-collection-models.js
+++ b/lib/rules/no-view-collection-models.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent access to collection's models property inside views",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-view-collection-models.md"
         },
         schema: []
     },

--- a/lib/rules/no-view-model-attributes.js
+++ b/lib/rules/no-view-model-attributes.js
@@ -15,7 +15,8 @@ module.exports = {
         docs: {
             description: "Prevent access to model's attributes collection inside views",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-view-model-attributes.md"
         },
         schema: []
     },

--- a/lib/rules/no-view-onoff-binding.js
+++ b/lib/rules/no-view-onoff-binding.js
@@ -16,7 +16,8 @@ module.exports = {
         docs: {
             description: "Prevent using on/off bindings inside views",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-view-onoff-binding.md"
         },
         schema: []
     },

--- a/lib/rules/no-view-qualified-jquery.js
+++ b/lib/rules/no-view-qualified-jquery.js
@@ -17,7 +17,8 @@ module.exports = {
         docs: {
             description: "Prevent usage of global $ to reach view elements",
             category: "Best Practices",
-            recommended: false
+            recommended: false,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/no-view-qualified-jquery.md"
         },
         schema: [
             {

--- a/lib/rules/render-return.js
+++ b/lib/rules/render-return.js
@@ -16,7 +16,8 @@ module.exports = {
         docs: {
             description: "Enforces render function to always return this",
             category: "Best Practices",
-            recommended: true
+            recommended: true,
+            url: "https://github.com/ilyavolodin/eslint-plugin-backbone/tree/master/docs/rules/render-return.md"
         },
         schema: []
     },


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.